### PR TITLE
빌드 매핑 리라이트 처리

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,5 +2,6 @@
 const nextConfig = {
   output: 'export',
   images: { unoptimized: true },
+   trailingSlash: true,
 };
 export default nextConfig;


### PR DESCRIPTION
Next.js 정적 export에서 trailingSlash 기본값이 false면,

/about → out/about.html

/blog/post → out/blog/post.html
처럼 폴더가 아니라 .html 파일로 생성

/BlockNote?category=guide 같은게 로딩 불가처리 됨

/BlockNote → out/BlockNote.html
로 매핑(리라이트)처리 해서 해결