### PR TITLE
깃 action 캐싱 전략 최적화

### DIFF
--- a/.github/workflows/frontend-exorts-main.yml
+++ b/.github/workflows/frontend-exorts-main.yml
@@ -1,3 +1,4 @@
+
 name: Build & Deploy (main)
 
 on:
@@ -16,7 +17,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -30,11 +31,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ap-northeast-2
         run: |
-          # 1) HTML/문서류 포함 전체를 짧게 캐시
-          aws s3 sync ./out s3://cat4uweb/ --delete \
-            --cache-control "public,max-age=300,must-revalidate"
+          set -euo pipefail
 
-          # 2) 정적 자산을 길게 캐시(파일명 해시가 붙어 있으니 안전)
+          # 1) 해시 정적 자산을 먼저 1년 캐시로 업로드
           if [ -d "./out/_next/static" ]; then
             aws s3 cp ./out/_next/static/ s3://cat4uweb/_next/static/ --recursive \
               --metadata-directive REPLACE \
@@ -47,19 +46,27 @@ jobs:
               --cache-control "public,max-age=31536000,immutable"
           fi
 
-      - name: Invalidate CloudFront Cache
+          # 2) 나머지(HTML 등)만 5분 캐시로 sync
+          aws s3 sync ./out s3://cat4uweb/ --delete \
+            --exclude "_next/static/*" \
+            --exclude "assets/*" \
+            --cache-control "public,max-age=300,must-revalidate"
+
+      - name: Invalidate CloudFront Cache (minimal)
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ap-northeast-2
-        run: aws cloudfront create-invalidation --distribution-id E15CALDAZ3RCDE --paths "/*"
+        run: |
+          set -euo pipefail
+          aws cloudfront create-invalidation --distribution-id E15CALDAZ3RCDE --paths "/" "/*/index.html"
 
-      # ✅ Discord 알림 (성공)
       - name: Notify Discord (Success, main)
         if: success()
         env:
           WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
+          set -euo pipefail
           SHA_SHORT="${GITHUB_SHA::7}"
           cat > payload.json <<'JSON'
           {
@@ -75,12 +82,12 @@ jobs:
           sed -i "s|\${RUN_URL}|https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}|g" payload.json
           curl -H "Content-Type: application/json" -X POST -d @payload.json "$WEBHOOK"
 
-      # ✅ Discord 알림 (실패)
       - name: Notify Discord (Failure, main)
         if: failure()
         env:
           WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
+          set -euo pipefail
           SHA_SHORT="${GITHUB_SHA::7}"
           cat > payload.json <<'JSON'
           {


### PR DESCRIPTION
1) 업로드 순서 변경

기존: sync(out 전체, 5분) → _next/static, assets를 cp(1년)로 “덮어쓰기”

변경: _next/static, assets를 먼저 cp(1년) → 나머지를 sync(5분)로 업로드

해결

“긴 캐시여야 하는 파일이 5분 캐시로 남는” 케이스를 원천 차단.

캐시 헤더가 업로드 순서에 덜 민감해짐.

2) sync에서 _next/static과 assets 제외

변경: aws s3 sync에 --exclude "_next/static/*" --exclude "assets/*"

해결

1년 캐시 대상이 sync로 다시 덮여서 5분 캐시로 바뀌는 문제 방지.

업로드 중복 감소.

3) CloudFront invalidation 범위 축소

기존: /* 전체 무효화

변경: "/" + "/*/index.html"만 무효화

해결

매 배포마다 전체 캐시를 날려서 오리진으로 튀는 현상 감소.

CloudFront 캐시 효율 개선. 응답 지연과 비용(오리진/전송/요청) 감소 가능.

4) 스크립트 안전성 강화

변경: 각 run 블록에 set -euo pipefail 추가

해결

AWS CLI나 shell 변수 문제 발생 시 “조용히 넘어가서 반쪽짜리 배포” 되는 상황을 줄임.

실패를 즉시 실패로 처리해서 CI가 더 신뢰 가능해짐.