### PR TITLE
🐛 글쓰기 페이지의 타이틀이 중앙으로 오도록 정렬

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -37,8 +37,8 @@ export default function Header() {
     <header className={shell}>
       <div className={container}>
         <div className={card}>
-          <div className={row}>
-            {/* Left: Brand / Burger */}
+          <div className={`${row} relative`}>
+            {/* Left */}
             <div className="flex items-center gap-2">
               <button
                 aria-label="메뉴 열기"
@@ -55,7 +55,17 @@ export default function Header() {
               </Link>
             </div>
 
-            {/* Center: Nav */}
+            {/* ✅ Center (mobile only): independent from left/right */}
+            <div className="md:hidden absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10">
+              <Link
+                href="/"
+                className="block max-w-[60vw] truncate text-center text-lg font-semibold tracking-tight text-[var(--text)]"
+              >
+                대물캣 커뮤니티
+              </Link>
+            </div>
+
+            {/* Center nav (md+) */}
             <nav className="hidden md:flex items-center justify-center gap-6 text-[var(--text)]" aria-label="주 메뉴">
               {NAV.map((item) => (
                 <NavLink key={item.href} href={item.href} current={pathname === item.href}>
@@ -64,15 +74,8 @@ export default function Header() {
               ))}
             </nav>
 
-            {/* Center: 모바일 전용 텍스트 브랜드 */}
-            <div className="md:hidden flex justify-center">
-              <Link href="/" className="text-lg font-semibold tracking-tight text-[var(--text)]">
-                대물캣 커뮤니티
-              </Link>
-            </div>
-
-            {/* Right: Profile */}
-            <div className="flex items-center justify-end gap-2">
+            {/* Right */}
+            <div className="flex items-center justify-end gap-2 shrink-0">
               {showProfileImage ? (
                 <>
                   <img


### PR DESCRIPTION
처음 CSS로드시 좌측 초상화,닉네임 부분에 닉네임이 없는 상태로 로드되어, API를 통해 닉네임이 들어오면 그만큼 글자가 좌측으로 쳐지는 문제가 있었다.

중앙 "대물캣 커뮤니티"글을 좌 우측 요소에 영향을 받지 않도록 부모 요소와 결합했다

수정전

<img width="1015" height="323" alt="image" src="https://github.com/user-attachments/assets/a7e35b15-99e5-4e7c-a683-edf8a3f9e1f2" />


수정후

<img width="1017" height="394" alt="image" src="https://github.com/user-attachments/assets/284d1044-5586-4d2d-9acc-f0781f761758" />
