### PR TITLE
🐛 하이드레이션 미스매치 수정

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -55,7 +55,16 @@ export default function Header() {
               </Link>
             </div>
 
-            {/* ✅ Center (mobile only): independent from left/right */}
+            {/* Center: Nav (md+) */}
+            <nav className="hidden md:flex items-center justify-center gap-6 text-[var(--text)]" aria-label="주 메뉴">
+              {NAV.map((item) => (
+                <NavLink key={item.href} href={item.href} current={pathname === item.href}>
+                  {item.label}
+                </NavLink>
+              ))}
+            </nav>
+
+            {/* Center: 모바일 전용 텍스트 브랜드 (항상 렌더) */}
             <div className="md:hidden absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10">
               <Link
                 href="/"
@@ -64,15 +73,6 @@ export default function Header() {
                 대물캣 커뮤니티
               </Link>
             </div>
-
-            {/* Center nav (md+) */}
-            <nav className="hidden md:flex items-center justify-center gap-6 text-[var(--text)]" aria-label="주 메뉴">
-              {NAV.map((item) => (
-                <NavLink key={item.href} href={item.href} current={pathname === item.href}>
-                  {item.label}
-                </NavLink>
-              ))}
-            </nav>
 
             {/* Right */}
             <div className="flex items-center justify-end gap-2 shrink-0">


### PR DESCRIPTION
중앙 타이틀 div를 “항상 렌더”하고, CSS로만 보이게/숨기게

조건 렌더를 없애고 구조를 고정

중앙 타이틀 div는 항상 존재

md:hidden으로 md 이상에서만 숨김

데스크탑 nav도 항상 존재하고 hidden md:flex로만 토글