### PR TITLE
♻️ 401 처리 흐름을 분리하고 단일 관제소로 통합

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -4,7 +4,6 @@ import ClientProviders from "../components/ClientProviders.jsx";
 import Header from "../components/Header";
 import BackgroundVideo from "./BackgroundVideo";
 import "./globals.css";
-import AuthSplashGate from "@/components/AuthSplashGate.jsx";
 
 export const metadata = {
   metadataBase: new URL("https://community.catalyst-for-you.com"),
@@ -42,7 +41,6 @@ export default function RootLayout({ children }) {
   return (
     <html lang="ko" suppressHydrationWarning>
       <body className="min-h-screen antialiased" suppressHydrationWarning>
-        <AuthSplashGate/>
         <BackgroundVideo />
         <ClientProviders>
           <Header />

--- a/components/ClientProviders.jsx
+++ b/components/ClientProviders.jsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { ToastProvider } from "@/components/ToastProvider";
 import AuthProvider from "@/components/AuthProvider";
+import { ToastProvider } from "@/components/ToastProvider";
+import AuthSplashGate from "./AuthSplashGate.jsx";
 
 export default function ClientProviders({ children }) {
   return (
     <ToastProvider>
-      <AuthProvider>{children}</AuthProvider>
+      <AuthProvider>
+        <AuthSplashGate />
+        {children}
+      </AuthProvider>
     </ToastProvider>
   );
 }

--- a/utils/authEvent.js
+++ b/utils/authEvent.js
@@ -1,0 +1,13 @@
+// utils/authEvents.js
+export const authEvents = (() => {
+  const listeners = new Set();
+  return {
+    onUnauthorized(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    emitUnauthorized(payload) {
+      for (const fn of listeners) fn(payload);
+    },
+  };
+})();

--- a/utils/fetchWithAuth.js
+++ b/utils/fetchWithAuth.js
@@ -1,32 +1,41 @@
 /**
- * 모든 API 요청은 해당 함수로 해야 로그인 페이지로 리디렉션이 가능함
- * @param {*} url
- * @param {*} options
- * @returns
+ * 모든 API 요청은 이 함수로.
+ * 401이면 여기서 로그인 시작하지 말고, 이벤트만 emit.
  */
-export async function fetchWithAuth(url, options = {}) {
-  const { redirectOn401 = true, on401 } = options;
+import { authEvents } from "./authEvent.js";
 
-  const res = await fetch(url, { credentials: "include", ...options });
+async function safeJson(res) {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchWithAuth(url, options = {}) {
+  const { emit401 = true, ...fetchOptions } = options;
+
+  const res = await fetch(url, {
+    credentials: "include",
+    cache: "no-store",
+    ...fetchOptions,
+  });
 
   if (res.status === 401) {
-    if (on401) await on401(); // UI 메시지, 스플래시 상태 변경 등
-
-    if (redirectOn401) {
-      const loginRes = await fetch("/api/esi/login", { credentials: "include" });
-      const { url: loginUrl } = await loginRes.json();
-      window.location.replace(loginUrl); // replace 권장
-    }
+    if (emit401) authEvents.emitUnauthorized({ url });
 
     const e = new Error("Unauthorized");
-    e.code = 401;
+    e.status = 401; // AuthProvider가 err.status를 보고 있으니 status로 맞춤
     throw e;
   }
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message || "서버 통신 중 오류가 발생했습니다.");
+    const data = await safeJson(res);
+    const e = new Error(data?.message || data?.error || "서버 통신 중 오류가 발생했습니다.");
+    e.status = res.status;
+    e.data = data;
+    throw e;
   }
 
-  return res.json();
+  return (await safeJson(res)) ?? {};
 }


### PR DESCRIPTION
fetchWithAuth에서 401 시 로그인 URL 생성 및 리다이렉트 제거.

401 발생 시 이벤트만 emit 하도록 변경.

AuthSplashGate가 401 이벤트를 구독해 로그인 시작을 1회로 고정.

state 중복 발급 및 클러스터 환경에서의 state mismatch 방지.

AuthProvider는 /api/esi/me로 “로그인 상태/프로필” 단일 소스로 유지.

스플래시는 초기 인증 체크 UX 정리 목적으로만 사용.