### PR TITLE
🐛nav가 모바일에서 빠져도, Right가 무조건 3번째 칸(col-start-3) 으로 가게 강제

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -29,7 +29,7 @@ const card =
   "glass rounded-2xl md:rounded-3xl border border-white/40 bg-white/60 backdrop-blur-2xl shadow-[0_10px_40px_rgba(0,0,0,0.25)]";
 
 // ✅ row는 그대로 두되, 큰 화면에서 좌우 여백이 살짝 더 있으면 안정감 있음
-const row = "px-4 py-3 md:px-6 md:py-4 relative md:grid md:grid-cols-[1fr,auto,1fr] items-center";
+const row = "px-4 py-3 md:px-6 md:py-4 relative grid grid-cols-[1fr,auto,1fr] items-center";
 
 const mobilePanel = "md:hidden border-t border-white/50";
 const linkMobile = "link-underline rounded-xl px-3 py-2 text-base text-[var(--muted)] hover:text-[var(--primary)]";
@@ -73,7 +73,7 @@ export default function Header() {
         <div ref={wrapRef} className={card}>
           <div className={`${row} relative`}>
             {/* Left */}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 col-start-1 justify-self-start">
               <button
                 aria-label="메뉴 열기"
                 aria-expanded={open}
@@ -94,7 +94,7 @@ export default function Header() {
 
             {/* Center: Nav (md+) */}
             <nav
-              className="hidden md:flex items-center justify-center gap-6 lg:gap-8 text-[var(--text)]"
+              className="hidden md:flex items-center justify-center gap-6 lg:gap-8 text-[var(--text)] col-start-2 justify-self-center"
               aria-label="주 메뉴"
             >
               {NAV.map((item) => (
@@ -115,7 +115,7 @@ export default function Header() {
             </div>
 
             {/* Right */}
-            <div className="flex items-center justify-end gap-2 shrink-0">
+            <div className="flex items-center justify-end gap-2 shrink-0 col-start-3 justify-self-end">
               {showProfileImage ? (
                 <>
                   <img


### PR DESCRIPTION
# 수정전

<img width="578" height="402" alt="image" src="https://github.com/user-attachments/assets/28794461-14c9-4bdd-aa42-6388a2c1faa2" />


---

# 수정후

<img width="585" height="396" alt="image" src="https://github.com/user-attachments/assets/67a290d5-6697-48f3-a41d-c000c0dbc5e9" />
